### PR TITLE
20250403_add:Gooogle_map

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,12 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# --------- 以下手動追加 --------
+  # 環境変数を管理することができるgemです。(.envファイルで使用)
+  gem 'dotenv-rails'
+
+
+# -------- ここまで --------
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,10 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.7)
+    dotenv-rails (3.1.7)
+      dotenv (= 3.1.7)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
     globalid (1.2.1)
@@ -311,6 +315,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv-rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # README
+## main
+- rails newを実施。
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## 01_Google-API_Javascript
 
-Things you may want to cover:
+### 参考URL
+  [【Rails6 / Google Map API】初学者向け！Ruby on Railsで簡単にGoogle Map APIの導入する](https://qiita.com/nagase_toya/items/e49977efb686ed05eadb)
 
-* Ruby version
+  [環境変数を使い、API KEYをアプリケーション内に隠す](https://qiita.com/JrPageboy/items/bba469a19353540c6231)
 
-* System dependencies
+### 手順
+- 1. GoogleMapのAPIキーを取得。
+- 2. Rootを「top_pages#index」に設定。
+- 3. mapsまでのルートを確立。
+- 4. Gem dotenv-railsをインストール (その後再起動)
+- 5. touch .envでファイルを作成。
+- 6. 手順5で作ったファイルに「GOOGLE_MAPS_API_KEY = "APIキー"」をファイルに記載。
+- 7. viewファイルのAPIキー入れる場所を「<%= ENV["GOOGLE_MAPS_API_KEY"] %>」という変数に変更。
 
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,0 +1,4 @@
+class MapsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/top_pages_controller.rb
+++ b/app/controllers/top_pages_controller.rb
@@ -1,0 +1,4 @@
+class TopPagesController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/maps_helper.rb
+++ b/app/helpers/maps_helper.rb
@@ -1,0 +1,2 @@
+module MapsHelper
+end

--- a/app/helpers/top_pages_helper.rb
+++ b/app/helpers/top_pages_helper.rb
@@ -1,0 +1,2 @@
+module TopPagesHelper
+end

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,0 +1,25 @@
+<h1>ここにGoogleMapを表示します</h1>
+<div id='map'></div>
+
+<style>
+  #map {
+    height: 600px;
+    width: 600px;
+  }
+</style>
+
+<script>
+let map
+let geocoder
+
+function initMap(){
+  geocoder = new google.maps.Geocoder()
+
+  map = new google.maps.Map(document.getElementById('map'), {
+    center: {lat: 35.7828, lng: 139.9653 },
+    zoom: 12,
+  });
+}
+
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&callback=initMap" async defer></script>

--- a/app/views/top_pages/index.html.erb
+++ b/app/views/top_pages/index.html.erb
@@ -1,0 +1,2 @@
+<h1>top_pages</h1>
+<%= link_to "マップへ", maps_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,7 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "top_pages#index"
+  get "top_pages", to: "top_page#index"
+  resources :maps, only: %i[index]
 end

--- a/test/controllers/maps_controller_test.rb
+++ b/test/controllers/maps_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MapsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/top_pages_controller_test.rb
+++ b/test/controllers/top_pages_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TopPagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#概要
- 0. Rails new
- 1. GoogleMapのAPIキーを取得。
- 2. Rootを「top_pages#index」に設定。
- 3. mapsまでのルートを確立。
- 4. Gem dotenv-railsをインストール (その後再起動)
- 5. touch .envでファイルを作成。
- 6. 手順5で作ったファイルに「GOOGLE_MAPS_API_KEY = "APIキー"」をファイルに記載。
- 7. viewファイルのAPIキー入れる場所を「<%= ENV["GOOGLE_MAPS_API_KEY"] %>」という変数に変更。